### PR TITLE
Genera schemas para cada tipo de XSD.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,20 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>pago10</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <packageName>com.vanjupe.contabilidad.pago10</packageName>
+                            <sources>
+                                <source>xml-resources/xsd/pago10</source>
+                            </sources>
+                            <extension>true</extension>
+                            <clearOutputDir>false</clearOutputDir>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>nomina</id>
                         <goals>
                             <goal>xjc</goal>

--- a/xml-resources/xsd/pago10/Pagos10.xsd
+++ b/xml-resources/xsd/pago10/Pagos10.xsd
@@ -1,12 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:pago10="http://www.sat.gob.mx/Pagos" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:catCFDI="http://www.sat.gob.mx/sitio_internet/cfd/catalogos"
            xmlns:tdCFDI="http://www.sat.gob.mx/sitio_internet/cfd/tipoDatos/tdCFDI"
            xmlns:catPagos="http://www.sat.gob.mx/sitio_internet/cfd/catalogos/Pagos"
            targetNamespace="http://www.sat.gob.mx/Pagos" elementFormDefault="qualified"
            attributeFormDefault="unqualified">
-    <xs:import namespace="http://www.sat.gob.mx/sitio_internet/cfd/catalogos"
-               schemaLocation="http://www.sat.gob.mx/sitio_internet/cfd/catalogos/catCFDI.xsd"/>
     <xs:import namespace="http://www.sat.gob.mx/sitio_internet/cfd/tipoDatos/tdCFDI"
                schemaLocation="http://www.sat.gob.mx/sitio_internet/cfd/tipoDatos/tdCFDI/tdCFDI.xsd"/>
     <xs:import namespace="http://www.sat.gob.mx/sitio_internet/cfd/catalogos/Pagos"
@@ -84,7 +81,7 @@
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:attribute>
-                                    <xs:attribute name="MonedaDR" use="required" type="catCFDI:c_Moneda">
+                                    <xs:attribute name="MonedaDR" use="required" type="pago10:c_MonedaPago">
                                         <xs:annotation>
                                             <xs:documentation>Atributo requerido para identificar la clave de la moneda
                                                 utilizada en los importes del documento relacionado, cuando se usa
@@ -116,7 +113,7 @@
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:attribute>
-                                    <xs:attribute name="MetodoDePagoDR" use="required" type="catCFDI:c_MetodoPago">
+                                    <xs:attribute name="MetodoDePagoDR" use="required" type="pago10:c_MetodoPagoPago">
                                         <xs:annotation>
                                             <xs:documentation>Atributo requerido para expresar la clave del método de
                                                 pago que se registró en el documento relacionado.
@@ -191,7 +188,7 @@
                                                         </xs:annotation>
                                                         <xs:complexType>
                                                             <xs:attribute name="Impuesto" use="required"
-                                                                          type="catCFDI:c_Impuesto">
+                                                                          type="pago10:c_ImpuestoPago">
                                                                 <xs:annotation>
                                                                     <xs:documentation>Atributo requerido para señalar la
                                                                         clave del tipo de impuesto retenido.
@@ -228,7 +225,7 @@
                                                         </xs:annotation>
                                                         <xs:complexType>
                                                             <xs:attribute name="Impuesto" use="required"
-                                                                          type="catCFDI:c_Impuesto">
+                                                                          type="pago10:c_ImpuestoPago">
                                                                 <xs:annotation>
                                                                     <xs:documentation>Atributo requerido para señalar la
                                                                         clave del tipo de impuesto trasladado.
@@ -236,7 +233,7 @@
                                                                 </xs:annotation>
                                                             </xs:attribute>
                                                             <xs:attribute name="TipoFactor" use="required"
-                                                                          type="catCFDI:c_TipoFactor">
+                                                                          type="pago10:c_TipoFactorPago">
                                                                 <xs:annotation>
                                                                     <xs:documentation>Atributo requerido para señalar la
                                                                         clave del tipo de factor que se aplica a la base
@@ -303,14 +300,14 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="FormaDePagoP" use="required" type="catCFDI:c_FormaPago">
+                        <xs:attribute name="FormaDePagoP" use="required" type="pago10:c_FormaPagoPago">
                             <xs:annotation>
                                 <xs:documentation>Atributo requerido para expresar la clave de la forma en que se
                                     realiza el pago.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="MonedaP" use="required" type="catCFDI:c_Moneda">
+                        <xs:attribute name="MonedaP" use="required" type="pago10:c_MonedaPago">
                             <xs:annotation>
                                 <xs:documentation>Atributo requerido para identificar la clave de la moneda utilizada
                                     para realizar el pago, cuando se usa moneda nacional se registra MXN. El atributo
@@ -505,4 +502,237 @@
             </xs:attribute>
         </xs:complexType>
     </xs:element>
+    <xs:simpleType name="c_MonedaPago">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse"/>
+            <xs:enumeration value="AED"/>
+            <xs:enumeration value="AFN"/>
+            <xs:enumeration value="ALL"/>
+            <xs:enumeration value="AMD"/>
+            <xs:enumeration value="ANG"/>
+            <xs:enumeration value="AOA"/>
+            <xs:enumeration value="ARS"/>
+            <xs:enumeration value="AUD"/>
+            <xs:enumeration value="AWG"/>
+            <xs:enumeration value="AZN"/>
+            <xs:enumeration value="BAM"/>
+            <xs:enumeration value="BBD"/>
+            <xs:enumeration value="BDT"/>
+            <xs:enumeration value="BGN"/>
+            <xs:enumeration value="BHD"/>
+            <xs:enumeration value="BIF"/>
+            <xs:enumeration value="BMD"/>
+            <xs:enumeration value="BND"/>
+            <xs:enumeration value="BOB"/>
+            <xs:enumeration value="BOV"/>
+            <xs:enumeration value="BRL"/>
+            <xs:enumeration value="BSD"/>
+            <xs:enumeration value="BTN"/>
+            <xs:enumeration value="BWP"/>
+            <xs:enumeration value="BYR"/>
+            <xs:enumeration value="BZD"/>
+            <xs:enumeration value="CAD"/>
+            <xs:enumeration value="CDF"/>
+            <xs:enumeration value="CHE"/>
+            <xs:enumeration value="CHF"/>
+            <xs:enumeration value="CHW"/>
+            <xs:enumeration value="CLF"/>
+            <xs:enumeration value="CLP"/>
+            <xs:enumeration value="CNY"/>
+            <xs:enumeration value="COP"/>
+            <xs:enumeration value="COU"/>
+            <xs:enumeration value="CRC"/>
+            <xs:enumeration value="CUC"/>
+            <xs:enumeration value="CUP"/>
+            <xs:enumeration value="CVE"/>
+            <xs:enumeration value="CZK"/>
+            <xs:enumeration value="DJF"/>
+            <xs:enumeration value="DKK"/>
+            <xs:enumeration value="DOP"/>
+            <xs:enumeration value="DZD"/>
+            <xs:enumeration value="EGP"/>
+            <xs:enumeration value="ERN"/>
+            <xs:enumeration value="ETB"/>
+            <xs:enumeration value="EUR"/>
+            <xs:enumeration value="FJD"/>
+            <xs:enumeration value="FKP"/>
+            <xs:enumeration value="GBP"/>
+            <xs:enumeration value="GEL"/>
+            <xs:enumeration value="GHS"/>
+            <xs:enumeration value="GIP"/>
+            <xs:enumeration value="GMD"/>
+            <xs:enumeration value="GNF"/>
+            <xs:enumeration value="GTQ"/>
+            <xs:enumeration value="GYD"/>
+            <xs:enumeration value="HKD"/>
+            <xs:enumeration value="HNL"/>
+            <xs:enumeration value="HRK"/>
+            <xs:enumeration value="HTG"/>
+            <xs:enumeration value="HUF"/>
+            <xs:enumeration value="IDR"/>
+            <xs:enumeration value="ILS"/>
+            <xs:enumeration value="INR"/>
+            <xs:enumeration value="IQD"/>
+            <xs:enumeration value="IRR"/>
+            <xs:enumeration value="ISK"/>
+            <xs:enumeration value="JMD"/>
+            <xs:enumeration value="JOD"/>
+            <xs:enumeration value="JPY"/>
+            <xs:enumeration value="KES"/>
+            <xs:enumeration value="KGS"/>
+            <xs:enumeration value="KHR"/>
+            <xs:enumeration value="KMF"/>
+            <xs:enumeration value="KPW"/>
+            <xs:enumeration value="KRW"/>
+            <xs:enumeration value="KWD"/>
+            <xs:enumeration value="KYD"/>
+            <xs:enumeration value="KZT"/>
+            <xs:enumeration value="LAK"/>
+            <xs:enumeration value="LBP"/>
+            <xs:enumeration value="LKR"/>
+            <xs:enumeration value="LRD"/>
+            <xs:enumeration value="LSL"/>
+            <xs:enumeration value="LYD"/>
+            <xs:enumeration value="MAD"/>
+            <xs:enumeration value="MDL"/>
+            <xs:enumeration value="MGA"/>
+            <xs:enumeration value="MKD"/>
+            <xs:enumeration value="MMK"/>
+            <xs:enumeration value="MNT"/>
+            <xs:enumeration value="MOP"/>
+            <xs:enumeration value="MRO"/>
+            <xs:enumeration value="MUR"/>
+            <xs:enumeration value="MVR"/>
+            <xs:enumeration value="MWK"/>
+            <xs:enumeration value="MXN"/>
+            <xs:enumeration value="MXV"/>
+            <xs:enumeration value="MYR"/>
+            <xs:enumeration value="MZN"/>
+            <xs:enumeration value="NAD"/>
+            <xs:enumeration value="NGN"/>
+            <xs:enumeration value="NIO"/>
+            <xs:enumeration value="NOK"/>
+            <xs:enumeration value="NPR"/>
+            <xs:enumeration value="NZD"/>
+            <xs:enumeration value="OMR"/>
+            <xs:enumeration value="PAB"/>
+            <xs:enumeration value="PEN"/>
+            <xs:enumeration value="PGK"/>
+            <xs:enumeration value="PHP"/>
+            <xs:enumeration value="PKR"/>
+            <xs:enumeration value="PLN"/>
+            <xs:enumeration value="PYG"/>
+            <xs:enumeration value="QAR"/>
+            <xs:enumeration value="RON"/>
+            <xs:enumeration value="RSD"/>
+            <xs:enumeration value="RUB"/>
+            <xs:enumeration value="RWF"/>
+            <xs:enumeration value="SAR"/>
+            <xs:enumeration value="SBD"/>
+            <xs:enumeration value="SCR"/>
+            <xs:enumeration value="SDG"/>
+            <xs:enumeration value="SEK"/>
+            <xs:enumeration value="SGD"/>
+            <xs:enumeration value="SHP"/>
+            <xs:enumeration value="SLL"/>
+            <xs:enumeration value="SOS"/>
+            <xs:enumeration value="SRD"/>
+            <xs:enumeration value="SSP"/>
+            <xs:enumeration value="STD"/>
+            <xs:enumeration value="SVC"/>
+            <xs:enumeration value="SYP"/>
+            <xs:enumeration value="SZL"/>
+            <xs:enumeration value="THB"/>
+            <xs:enumeration value="TJS"/>
+            <xs:enumeration value="TMT"/>
+            <xs:enumeration value="TND"/>
+            <xs:enumeration value="TOP"/>
+            <xs:enumeration value="TRY"/>
+            <xs:enumeration value="TTD"/>
+            <xs:enumeration value="TWD"/>
+            <xs:enumeration value="TZS"/>
+            <xs:enumeration value="UAH"/>
+            <xs:enumeration value="UGX"/>
+            <xs:enumeration value="USD"/>
+            <xs:enumeration value="USN"/>
+            <xs:enumeration value="UYI"/>
+            <xs:enumeration value="UYU"/>
+            <xs:enumeration value="UZS"/>
+            <xs:enumeration value="VEF"/>
+            <xs:enumeration value="VND"/>
+            <xs:enumeration value="VUV"/>
+            <xs:enumeration value="WST"/>
+            <xs:enumeration value="XAF"/>
+            <xs:enumeration value="XAG"/>
+            <xs:enumeration value="XAU"/>
+            <xs:enumeration value="XBA"/>
+            <xs:enumeration value="XBB"/>
+            <xs:enumeration value="XBC"/>
+            <xs:enumeration value="XBD"/>
+            <xs:enumeration value="XCD"/>
+            <xs:enumeration value="XDR"/>
+            <xs:enumeration value="XOF"/>
+            <xs:enumeration value="XPD"/>
+            <xs:enumeration value="XPF"/>
+            <xs:enumeration value="XPT"/>
+            <xs:enumeration value="XSU"/>
+            <xs:enumeration value="XTS"/>
+            <xs:enumeration value="XUA"/>
+            <xs:enumeration value="XXX"/>
+            <xs:enumeration value="YER"/>
+            <xs:enumeration value="ZAR"/>
+            <xs:enumeration value="ZMW"/>
+            <xs:enumeration value="ZWL"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="c_FormaPagoPago">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse"/>
+            <xs:enumeration value="01"/>
+            <xs:enumeration value="02"/>
+            <xs:enumeration value="03"/>
+            <xs:enumeration value="04"/>
+            <xs:enumeration value="05"/>
+            <xs:enumeration value="06"/>
+            <xs:enumeration value="08"/>
+            <xs:enumeration value="12"/>
+            <xs:enumeration value="13"/>
+            <xs:enumeration value="14"/>
+            <xs:enumeration value="15"/>
+            <xs:enumeration value="17"/>
+            <xs:enumeration value="23"/>
+            <xs:enumeration value="24"/>
+            <xs:enumeration value="25"/>
+            <xs:enumeration value="26"/>
+            <xs:enumeration value="27"/>
+            <xs:enumeration value="28"/>
+            <xs:enumeration value="29"/>
+            <xs:enumeration value="30"/>
+            <xs:enumeration value="31"/>
+            <xs:enumeration value="99"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="c_MetodoPagoPago">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse"/>
+            <xs:enumeration value="PUE"/>
+            <xs:enumeration value="PPD"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="c_ImpuestoPago">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse"/>
+            <xs:enumeration value="001"/>
+            <xs:enumeration value="002"/>
+            <xs:enumeration value="003"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="c_TipoFactorPago">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="collapse"/>
+            <xs:enumeration value="Tasa"/>
+            <xs:enumeration value="Cuota"/>
+            <xs:enumeration value="Exento"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Separamos pago de cfdi
Se agregan tipos especiales en pago para evitar nombres duplicados con cfdi en tipos de datos.